### PR TITLE
[UI/#24] 독서 맵 -> 바텀 시트 구현

### DIFF
--- a/app/src/main/res/drawable/drawer_item_outline.xml
+++ b/app/src/main/res/drawable/drawer_item_outline.xml
@@ -1,0 +1,10 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+    <shadowColor android:color="#000000"/>
+    <shadowDx android:value="0"/>
+    <shadowDy android:value="-4"/>
+    <shadowRadius android:value="8"/>
+    <stroke
+        android:width="0.5dp"
+        android:color='#A4A4A4'/>
+</shape>

--- a/app/src/main/res/drawable/drawer_little_corner.xml
+++ b/app/src/main/res/drawable/drawer_little_corner.xml
@@ -1,0 +1,9 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+    <corners android:topLeftRadius="12dp"
+        android:topRightRadius="12dp"/>
+    <shadowColor android:color="#000000"/>
+    <shadowDx android:value="0"/>
+    <shadowDy android:value="-4"/>
+    <shadowRadius android:value="8"/>
+</shape>

--- a/app/src/main/res/layout/fragment_map_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_map_bottom_sheet.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_item_map_book_bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="@drawable/drawer_corner"
+        android:layout_margin="1dp"
+        android:elevation="10dp">
+
+        <LinearLayout
+            android:id="@+id/fragment_top"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="15dp"
+            android:paddingBottom="10dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/iv_back_arrow"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:src="@drawable/ic_arrow_back" />
+
+                <TextView
+                    android:id="@+id/tv_record_registration"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="8"
+                    android:fontFamily="@font/pretendard_regular"
+                    android:gravity="center_horizontal"
+                    android:text="숭실대학교"
+                    android:textColor="@color/black"
+                    android:textSize="17sp" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="right"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+
+            <View
+                android:id="@+id/view_line"
+                android:layout_width="330dp"
+                android:layout_height="2px"
+                android:layout_marginStart="13dp"
+                android:layout_marginTop="15dp"
+                android:layout_marginBottom="5dp"
+                android:background="@color/black" />
+
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_map_place_book_list"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_horizontal"
+                tools:itemCount="3"
+                tools:listitem="@layout/item_map_book_list" />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_record_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_record_bottom_sheet.xml
@@ -4,12 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_final_record_bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:background="@drawable/drawer_corner"
         android:layout_margin="1dp"
         android:elevation="10dp">
+
         <LinearLayout
             android:id="@+id/fragment_top"
             android:layout_width="match_parent"
@@ -64,7 +66,7 @@
                 android:background="@color/black" />
 
             <TextView
-                android:id="@+id/tv_final_record_memo"
+                android:id="@+id/tv_final_record_review"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="한줄평"
@@ -75,7 +77,7 @@
                 android:layout_marginTop="2dp"/>
 
             <ImageView
-                android:id="@+id/iv_final_record_memo"
+                android:id="@+id/iv_final_record_review"
                 android:layout_width="330dp"
                 android:layout_height="wrap_content"
                 android:src="@drawable/iv_record_read_page_background"
@@ -83,6 +85,7 @@
                 android:layout_marginTop="1dp"/>
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_final_record_score"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="7dp">
@@ -102,7 +105,7 @@
                     tools:ignore="NotSibling" />
 
                 <LinearLayout
-                    android:id="@+id/layout_final_record_score"
+                    android:id="@+id/layout_final_record_score_star"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="13dp"

--- a/app/src/main/res/layout/fragment_record_map_search.xml
+++ b/app/src/main/res/layout/fragment_record_map_search.xml
@@ -88,7 +88,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/et_record_map_search"
-        tools:itemCount="41"
+        tools:itemCount="4"
         tools:listitem="@layout/item_map_search" />
 
     <Button

--- a/app/src/main/res/layout/item_map_book_list.xml
+++ b/app/src/main/res/layout/item_map_book_list.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <!-- ConstraintLayout 내부의 개별 아이템 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_item_map_book_top"
+        android:layout_width="320dp"
+        android:layout_height="70dp"
+        android:background="@drawable/drawer_little_corner"
+        android:backgroundTint="#5B5443"
+        android:padding="8dp"
+        android:layout_marginVertical="8dp"
+        android:layout_gravity="center_horizontal"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <!-- 책 이미지 -->
+        <ImageView
+            android:id="@+id/iv_book_image"
+            android:layout_width="41dp"
+            android:layout_height="51dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/iv_book_dummy"
+            android:paddingTop="2dp"
+            android:layout_marginStart="10dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <!-- 제목 텍스트 -->
+        <TextView
+            android:id="@+id/tv_book_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="채식주의자"
+            android:layout_marginTop="3dp"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:textSize="14sp"
+            android:paddingStart="5dp"
+            app:layout_constraintStart_toEndOf="@id/iv_book_image"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginStart="8dp" />
+
+        <!-- 저자 텍스트 -->
+        <TextView
+            android:id="@+id/tv_book_author"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="한강"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:paddingStart="5dp"
+            app:layout_constraintStart_toEndOf="@id/iv_book_image"
+            app:layout_constraintTop_toBottomOf="@id/tv_book_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="4dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- RecyclerView 설정 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_map_book_phrase_list"
+        android:layout_width="320dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/layout_item_map_book_top"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/item_map_book_record_list"
+        tools:itemCount="2" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_map_book_record_list.xml
+++ b/app/src/main/res/layout/item_map_book_record_list.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@drawable/drawer_item_outline"
+    android:layout_gravity="center_horizontal"
+    android:padding="10dp">
+
+    <TextView
+        android:id="@+id/tv_item_map_book_record_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="이 책은 정말 재미지다"
+        android:textSize="14sp"
+        android:textColor="@color/black"
+        android:fontFamily="@font/pretendard_bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="-5dp"/>
+
+    <TextView
+        android:id="@+id/tv_like_phrase"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="안진진, 나와 결혼 해줄거지요?안진진, 나와 결혼 해줄거지요?"
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        android:fontFamily="@font/pretendard_regular"
+        android:layout_marginTop="1.5dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_item_map_book_record_title"/>
+    <TextView
+        android:id="@+id/tv_record_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_light"
+        android:text="2024.11.02"
+        android:textSize="10sp"
+        android:layout_marginTop="1.5dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_like_phrase"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
독서 맵 바텀 시트 구현 완료
<img width="287" alt="스크린샷 2024-11-07 오후 11 48 38" src="https://github.com/user-attachments/assets/8d1f8aaf-5679-41c9-b349-f5850923328e">
